### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/alibabacloud.yml
+++ b/.github/workflows/alibabacloud.yml
@@ -19,6 +19,11 @@
 
 name: Build and Deploy to ACK
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/melissamforbs/stormx-token/security/code-scanning/1](https://github.com/melissamforbs/stormx-token/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the workflow. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing container images to ACR.
- `id-token: write` for authentication with OpenID Connect (OIDC), if required by any of the actions.

The `permissions` block will be added at the root level, applying to all jobs in the workflow. If any job requires additional permissions, they can be defined specifically within that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
